### PR TITLE
Add RAG-only mode to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The Crawl4AI RAG MCP server is just the beginning. Here's where we're headed:
 
 The server provides essential web crawling and search tools:
 
+> **Tip**: Set `ENABLE_CRAWLING_TOOLS=false` in your `.env` file to disable the
+> crawling tools entirely and run the server in RAG-only mode.
+
 ### Core Tools (Always Available)
 
 1. **`crawl_single_page`**: Quickly crawl a single web page and store its content in the vector database
@@ -131,6 +134,8 @@ Create a `.env` file in the project root with the following variables:
 HOST=0.0.0.0
 PORT=8051
 TRANSPORT=sse
+ENABLE_CRAWLING_TOOLS=true
+# Set to "false" to disable crawling tools and run the server in RAG-only mode
 
 # OpenAI API Configuration
 OPENAI_API_KEY=your_openai_api_key

--- a/src/crawl4ai_mcp.py
+++ b/src/crawl4ai_mcp.py
@@ -43,6 +43,9 @@ dotenv_path = project_root / '.env'
 # Force override of existing environment variables
 load_dotenv(dotenv_path, override=True)
 
+# Determine whether crawling tools should be exposed
+ENABLE_CRAWLING_TOOLS = os.getenv("ENABLE_CRAWLING_TOOLS", "true").lower() == "true"
+
 # Create a dataclass for our application context
 @dataclass
 class Crawl4AIContext:
@@ -265,8 +268,9 @@ def process_code_example(args):
     code, context_before, context_after = args
     return generate_code_example_summary(code, context_before, context_after)
 
-@mcp.tool()
-async def crawl_single_page(ctx: Context, url: str) -> str:
+if ENABLE_CRAWLING_TOOLS:
+    @mcp.tool()
+    async def crawl_single_page(ctx: Context, url: str) -> str:
     """
     Crawl a single web page and store its content in Supabase.
     
@@ -405,8 +409,9 @@ async def crawl_single_page(ctx: Context, url: str) -> str:
             "error": str(e)
         }, indent=2)
 
-@mcp.tool()
-async def smart_crawl_url(ctx: Context, url: str, max_depth: int = 3, max_concurrent: int = 10, chunk_size: int = 5000) -> str:
+if ENABLE_CRAWLING_TOOLS:
+    @mcp.tool()
+    async def smart_crawl_url(ctx: Context, url: str, max_depth: int = 3, max_concurrent: int = 10, chunk_size: int = 5000) -> str:
     """
     Intelligently crawl a URL based on its type and store content in Supabase.
     


### PR DESCRIPTION
## Summary
- allow disabling crawling tools via `ENABLE_CRAWLING_TOOLS` env var
- document new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684334079f9c83258a7e162697d9ef0d